### PR TITLE
get results cohort by cohort

### DIFF
--- a/R/matchedDiagnostics.R
+++ b/R/matchedDiagnostics.R
@@ -40,38 +40,43 @@ matchedDiagnostics <- function(cohort,
     dplyr::select("cohort_definition_id") |>
     dplyr::pull()
 
+  prefix <- omopgenerics::tmpPrefix()
+  tempCohortTable  <- paste0(prefix, cohortName)
   results <- list()
-  matchedCohortTable <- paste0(omopgenerics::tableName(cdm[[cohortName]]),
-                               "_matched")
 
+  for(i in seq_along(cohortIds)){
+    workingCohortId <- cohortIds[i]
+    workingCohortName <- omopgenerics::getCohortName(cdm[[cohortName]],
+                                                   cohortId = workingCohortId)
+
+  cdm[[tempCohortTable]] <- CohortConstructor::subsetCohorts(
+      cdm[[cohortName]],
+      cohortId = workingCohortId,
+      name = tempCohortTable)
   if(!is.null(matchedSample)){
   cli::cli_bullets(c("*" = "{.strong Sampling cohorts}"))
-  cdm[[matchedCohortTable]] <- CohortConstructor::sampleCohorts(cdm[[cohortName]],
+  cdm[[tempCohortTable]] <- CohortConstructor::sampleCohorts(cdm[[tempCohortTable]],
+                                   cohortId = workingCohortId,
                                    n = matchedSample,
-                                   name = matchedCohortTable)
-  } else {
-    cdm[[matchedCohortTable]] <- cdm[[cohortName]] |>
-      dplyr::compute(name = matchedCohortTable, temporary = FALSE,
-                     logPrefix = "PhenotypeR_matched_")
+                                   name = tempCohortTable)
   }
 
-  cli::cli_bullets(c("*" = "{.strong Generating a age and sex matched cohorts}"))
-  cdm[[matchedCohortTable]] <- CohortConstructor::matchCohorts(cdm[[matchedCohortTable]],
-                                     name = matchedCohortTable)
-
-  cdm[[matchedCohortTable]]  <- cdm[[matchedCohortTable]] |>
+  cli::cli_bullets(c("*" = "{.strong Generating an age and sex matched cohort for {workingCohortName}}"))
+  cdm[[tempCohortTable]] <- CohortConstructor::matchCohorts(cdm[[tempCohortTable]],
+                                     name = tempCohortTable)
+  cdm[[tempCohortTable]]  <- cdm[[tempCohortTable]] |>
     PatientProfiles::addDemographics(age = TRUE,
-                                     ageGroup = list(c(0, 17), c(18, 64), c(65, 150)),
+                                     ageGroup = list(c(0, 17),
+                                                     c(18, 64),
+                                                     c(65, 150)),
                                      sex = TRUE,
                                      priorObservation = FALSE,
                                      futureObservation = FALSE,
                                      dateOfBirth = FALSE,
-                                     name = matchedCohortTable)
+                                     name = tempCohortTable)
+  cdm[[tempCohortTable]] <- CohortConstructor::addCohortTableIndex(cdm[[tempCohortTable]])
 
-  cli::cli_bullets(c("*" = "Index matched cohort table"))
-  cdm[[matchedCohortTable]] <- CohortConstructor::addCohortTableIndex(cdm[[matchedCohortTable]])
-
-  results[["cohort_summary"]] <- cdm[[matchedCohortTable]] |>
+  results[[paste0("cohort_summary_", workingCohortName)]] <- cdm[[tempCohortTable]] |>
     CohortCharacteristics::summariseCharacteristics(
       strata = list("age_group", "sex"),
       tableIntersectCount = list(
@@ -83,7 +88,7 @@ matchedDiagnostics <- function(cohort,
     )
 
   cli::cli_bullets(c("*" = "Getting age density"))
-  results[["cohort_density"]] <- cdm[[matchedCohortTable]] |>
+  results[[paste0("cohort_density_", workingCohortName)]] <- cdm[[tempCohortTable]] |>
     PatientProfiles::addCohortName() |>
     PatientProfiles::summariseResult(
       strata    = "sex",
@@ -91,12 +96,11 @@ matchedDiagnostics <- function(cohort,
       group     = "cohort_name",
       includeOverallGroup  = FALSE,
       variables = "age",
-      estimates = "density") |>
-    suppressMessages()
+      estimates = "density")
 
   cli::cli_bullets(c("*" = "{.strong Running large scale characterisation}"))
-  results[["lsc"]] <- CohortCharacteristics::summariseLargeScaleCharacteristics(
-    cohort = cdm[[matchedCohortTable]],
+  results[[paste0("lsc_", workingCohortName)]] <- CohortCharacteristics::summariseLargeScaleCharacteristics(
+    cohort = cdm[[tempCohortTable]],
     window = list(c(-Inf, -1), c(-Inf, -366), c(-365, -31),
                   c(-30, -1), c(0, 0),
                   c(1, 30), c(31, 365),
@@ -109,6 +113,9 @@ matchedDiagnostics <- function(cohort,
     includeSource = TRUE,
     excludedCodes = NULL
   )
+  }
+
+  omopgenerics::dropTable(cdm, dplyr::starts_with(prefix))
 
   results <- results |>
     vctrs::list_drop_empty() |>

--- a/tests/testthat/test-matchedDiagnostics.R
+++ b/tests/testthat/test-matchedDiagnostics.R
@@ -32,3 +32,30 @@ test_that("cohort to pop diagnostics", {
 
 
 })
+
+test_that("run with multiple cohorts", {
+  testthat::skip_on_cran()
+
+  cdm_local <- omock::mockCdmReference() |>
+    omock::mockPerson(nPerson = 100) |>
+    omock::mockObservationPeriod() |>
+    omock::mockConditionOccurrence() |>
+    omock::mockDrugExposure() |>
+    omock::mockObservation() |>
+    omock::mockMeasurement() |>
+    omock::mockVisitOccurrence() |>
+    omock::mockProcedureOccurrence() |>
+    omock::mockCohort(name = "my_cohort", numberCohorts = 2)
+
+  db <- DBI::dbConnect(duckdb::duckdb())
+  cdm <- CDMConnector::copyCdmTo(con = db, cdm = cdm_local,
+                                 schema ="main", overwrite = TRUE)
+  expect_no_error(result <- cdm$my_cohort |>
+                    matchedDiagnostics())
+
+  expect_identical(sort(unique(result$group_level)),
+  c("cohort_1_matched", "cohort_1_sampled",
+    "cohort_2_matched", "cohort_2_sampled")
+  )
+
+})


### PR DESCRIPTION
To reduce memory requirements when there are many cohorts of interest, run cohort and matched diagnostics cohort by cohort